### PR TITLE
Improve /search command

### DIFF
--- a/modules/sphinx_parser.py
+++ b/modules/sphinx_parser.py
@@ -24,6 +24,10 @@ async def search_from_sphinx(url, keyword, fuzzSort=True):
         data = [x.get("href") for x in soup.find_all("a") if len(x.get("href")) > 3]
 
         for val in data:
+            # remove any links to github or sphinx, we're after docs pages here
+            if re.search(r'\.org*?$', val) or val.startswith("https://github.com/"):
+                continue
+
             # get topic of each link, while still preserving the link itself
             val = (val, re.sub(r'\.html$', '', val)
                    .split(".")[-1]
@@ -35,7 +39,6 @@ async def search_from_sphinx(url, keyword, fuzzSort=True):
 
         # get top 5 values
         data = sorted(rData, key=rData.get, reverse=True)[:5]
-
 
     else:
         data = [x.get("href") for x in soup.findAll("a") if keyword in str(x).lower()]

--- a/modules/sphinx_parser.py
+++ b/modules/sphinx_parser.py
@@ -1,10 +1,43 @@
+import re
 import aiohttp
 from bs4 import BeautifulSoup
+from fuzzywuzzy import fuzz
 
 
-async def search_from_sphinx(url, keyword):
+async def search_from_sphinx(url, keyword, fuzzSort=True):
+    """
+    Searches sphinx for a pages matching keyword
+    :param url: url of sphinx docs
+    :param keyword: the keyword to search for
+    :param fuzzSort: should fuzzy matching/sorting be used
+    :return: list of matches
+    """
+    keyword = keyword.lower()
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as res:
             text = await res.read()
     soup = BeautifulSoup(text, "html.parser")
-    return [x.get("href") for x in soup.findAll("a") if keyword in str(x)]
+
+    if fuzzSort:
+        # utilises fuzzy string matching to determine which page is most likely to be what the user wants
+        rData = {}
+        data = [x.get("href") for x in soup.find_all("a") if len(x.get("href")) > 3]
+
+        for val in data:
+            # get topic of each link, while still preserving the link itself
+            val = (val, re.sub(r'\.html$', '', val)
+                   .split(".")[-1]
+                   .replace("_", " "))
+
+            # determine how similar this topic is to the keyword
+            ratio = fuzz.ratio(val[1].lower(), keyword)
+            rData[val[0]] = ratio
+
+        # get top 5 values
+        data = sorted(rData, key=rData.get, reverse=True)[:5]
+
+
+    else:
+        data = [x.get("href") for x in soup.findAll("a") if keyword in str(x).lower()]
+
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discord.py
 discord-py-slash-command >= 1.0.9
 aiosqlite
+fuzzywuzzy[speedup]


### PR DESCRIPTION
The `/search` command could be very useful, but I feel it has a few fatal flaws which prevent this. 

For one, it's case-sensitive. This PR resolves this by adding `.lower()` to `search_from_sphinx`.

Secondly, it can't handle the user making a typo, or using incomplete names. To resolve this I've added fuzzy string matching to `search_from_sphinx`. 

I've also added an optional argument to the parser, allowing the fuzzy matching to be toggled (default on), as I can appreciate in some situations fuzzy matching isn't optimal 